### PR TITLE
feat: using parameterized statements for fetching table-items

### DIFF
--- a/db_init/schema.sql
+++ b/db_init/schema.sql
@@ -8,6 +8,6 @@ CREATE TABLE IF NOT EXISTS table_items (
   item_name VARCHAR(127) NOT NULL,
   prepare_minutes INT UNSIGNED NOT NULL,
   ordered_on DATETIME NOT NULL
-);
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci;
 
 CREATE INDEX index_on_table_number ON table_items (table_number);

--- a/src/model/error_model.rs
+++ b/src/model/error_model.rs
@@ -2,6 +2,7 @@ use actix_web::{HttpResponse, ResponseError};
 use derive_more::{Display, Error, From};
 use log::{error};
 use serde::Serialize;
+use mysql::Error;
 
 #[derive(Debug, Display, Error, From)]
 pub enum PersistenceError {
@@ -48,4 +49,24 @@ impl ResponseError for PersistenceError {
             }
         }
     }
+}
+
+
+#[derive(Debug, Display, Error, From)]
+pub enum MysqlValueError {
+    MissingString,
+    MissingInteger,
+    MissingDatetime
+}
+
+pub fn generate_mysql_value_error(err_type: MysqlValueError, column_name: String) -> Error {
+    Error::MySqlError(mysql::MySqlError {
+        state: "failed".to_string(),
+        code: match err_type {
+            MysqlValueError::MissingString => 1,
+            MysqlValueError::MissingInteger => 2,
+            MysqlValueError::MissingDatetime => 3
+        },
+        message: format!("Error: Issue with value existing in column({column_name})"),
+    })
 }

--- a/src/repository/fetch_table_items.rs
+++ b/src/repository/fetch_table_items.rs
@@ -70,13 +70,13 @@ fn row_to_table_item(row: Result<Row, mysql::Error>) -> Result<TableItem, mysql:
     let row = row?;
     let item_id: u32 = row.get(0)
         .ok_or_else(|| mysql::Error::MySqlError(mysql::MySqlError {
-            state: "error".to_string(),
+            state: "Error: Conversion to u32 failed".to_string(),
             code: 0,
             message: "Missing item_id".into(),
         }))?;
     let table_number: u32 = row.get(1)
         .ok_or_else(|| mysql::Error::MySqlError(mysql::MySqlError {
-            state: "error".to_string(),
+            state: "Error: Conversion to u32 failed".to_string(),
             code: 0,
             message: "Missing table_number".into(),
         }))?;
@@ -84,14 +84,14 @@ fn row_to_table_item(row: Result<Row, mysql::Error>) -> Result<TableItem, mysql:
         Some(Value::Bytes(bytes)) => String::from_utf8_lossy(&*bytes).into_owned(),
         Some(other) => from_value(other),
         None => return Err(mysql::Error::MySqlError(mysql::MySqlError {
-            state: "error".to_string(),
+            state: "Error: Conversion to u32 failed".to_string(),
             code: 0,
             message: "Missing item_name".into(),
         })),
     };
     let prepare_minutes: u32 = row.get(3)
         .ok_or_else(|| mysql::Error::MySqlError(mysql::MySqlError {
-            state: "error".to_string(),
+            state: "Error: Conversion to u32 failed".to_string(),
             code: 0,
             message: "Missing prepare_minutes".into(),
         }))?;
@@ -104,8 +104,8 @@ fn row_to_table_item(row: Result<Row, mysql::Error>) -> Result<TableItem, mysql:
         },
         Some(other) => from_value(other),
         None => return Err(mysql::Error::MySqlError(mysql::MySqlError {
-            state: "error".to_string(),
-            code: 0,
+            state: "Error: Conversion to String failed".to_string(),
+            code: 1,
             message: "Missing ordered_on".into(),
         })),
     };

--- a/src/repository/fetch_table_items.rs
+++ b/src/repository/fetch_table_items.rs
@@ -1,45 +1,136 @@
 use crate::model::error_model::PersistenceError;
-use crate::model::response_model::{ListTableItemsResponse};
+use crate::model::response_model::ListTableItemsResponse;
 use crate::model::table_model::TableItem;
 use actix_request_identifier::RequestId;
-use log::{debug, error};
+use log::{debug, error, warn};
 use mysql::prelude::*;
-use mysql::{Pool};
+use mysql::{from_value, Pool, Value, Row};
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
-pub fn get_table_items(pool: &Pool,
-                       request_id: RequestId,
-                       table_number: u32,
-                       items_ids: Option<Vec<u32>>,
-                       items_names: Option<Vec<String>>,
+pub fn get_table_items(
+    pool: &Pool,
+    request_id: RequestId,
+    table_number: u32,
+    items_ids: Option<Vec<u32>>,
+    items_names: Option<Vec<String>>,
 ) -> Result<ListTableItemsResponse, PersistenceError> {
-    let query = generate_query(table_number, items_ids, items_names);
+    let mut query = String::from("SELECT * FROM table_items WHERE table_number = ?");
+    let mut params: Vec<Value> = vec![Value::from(table_number)];
+    let mut conditions = Vec::new();
+
+    if let Some(ref items_ids) = items_ids {
+        if !items_ids.is_empty() {
+            conditions.push(format!("item_id IN ({})", vec!["?"; items_ids.len()].join(",")));
+            params.extend(items_ids.iter().map(|&id| Value::from(id)));
+        }
+    }
+
+    if let Some(ref items_names) = items_names {
+        if !items_names.is_empty() {
+            conditions.push(format!("item_name IN ({})", vec!["?"; items_names.len()].join(",")));
+            params.extend(items_names.iter().map(|name| Value::from(name.clone())));
+        }
+    }
+
+    if !conditions.is_empty() {
+        query.push_str(" AND ");
+        if conditions.len() == 2 {
+            query.push_str(&format!("( {} )", conditions.join(" OR ")));
+        } else {
+            query.push_str(&conditions.join(" OR "));
+        }
+    }
+
     debug!("{request_id}; SQL Prepared for get table items");
 
     let mut conn = pool.get_conn().map_err(|_| PersistenceError::DBConnError)?;
-    match conn.query_map(
-        query,
-        |(item_id, table_number, item_name, prepare_minutes, ordered_on)
-        | TableItem { item_id, table_number, item_name, prepare_minutes, ordered_on }
-    ) {
-        Ok(table_items) => {
-            debug!("{request_id}; SQL Executed successfully");
-            Ok(generate_success_response(table_items))
+    let x = match conn.exec_iter(query, params) {
+        Ok(result) => {
+            let table_items: Vec<TableItem> = result
+                .map(|row| row_to_table_item(row))
+                .filter_map(Result::ok)
+                .collect();
+
+            if table_items.is_empty() {
+                warn!("{request_id}; No valid table items found");
+                Ok(generate_empty_response())
+            } else {
+                debug!("{request_id}; SQL Executed successfully");
+                Ok(generate_success_response(table_items))
+            }
         }
         Err(e) => {
-            debug!("{request_id}; SQL Execution failed");
-            error!("{:?}", e);
+            error!("{request_id}; SQL Execution failed: {:?}", e);
             Ok(generate_failed_response())
         }
-    }
+    }; x
 }
 
+fn row_to_table_item(row: Result<Row, mysql::Error>) -> Result<TableItem, mysql::Error> {
+    let row = row?;
+    let item_id: u32 = row.get(0)
+        .ok_or_else(|| mysql::Error::MySqlError(mysql::MySqlError {
+            state: "error".to_string(),
+            code: 0,
+            message: "Missing item_id".into(),
+        }))?;
+    let table_number: u32 = row.get(1)
+        .ok_or_else(|| mysql::Error::MySqlError(mysql::MySqlError {
+            state: "error".to_string(),
+            code: 0,
+            message: "Missing table_number".into(),
+        }))?;
+    let item_name: String = match row.get(2) {
+        Some(Value::Bytes(bytes)) => String::from_utf8_lossy(&*bytes).into_owned(),
+        Some(other) => from_value(other),
+        None => return Err(mysql::Error::MySqlError(mysql::MySqlError {
+            state: "error".to_string(),
+            code: 0,
+            message: "Missing item_name".into(),
+        })),
+    };
+    let prepare_minutes: u32 = row.get(3)
+        .ok_or_else(|| mysql::Error::MySqlError(mysql::MySqlError {
+            state: "error".to_string(),
+            code: 0,
+            message: "Missing prepare_minutes".into(),
+        }))?;
+    let ordered_on: String = match row.get(4) {
+        Some(Value::Date(year, month, day, hour, minute, second, _micro_second)) => {
+            NaiveDateTime::new(
+                NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32).unwrap(),
+                NaiveTime::from_hms_opt(hour as u32, minute as u32, second as u32).unwrap()
+            ).format("%Y-%m-%d %H:%M:%S").to_string()
+        },
+        Some(other) => from_value(other),
+        None => return Err(mysql::Error::MySqlError(mysql::MySqlError {
+            state: "error".to_string(),
+            code: 0,
+            message: "Missing ordered_on".into(),
+        })),
+    };
 
-
+    Ok(TableItem {
+        item_id,
+        table_number,
+        item_name,
+        prepare_minutes,
+        ordered_on,
+    })
+}
 
 fn generate_failed_response() -> ListTableItemsResponse {
     ListTableItemsResponse {
         status: "failed".to_string(),
-        message: "Could not find desired table items".to_string(),
+        message: "Could not fetch table items".to_string(),
+        table_items: Vec::new(),
+    }
+}
+
+fn generate_empty_response() -> ListTableItemsResponse {
+    ListTableItemsResponse {
+        status: "success".to_string(),
+        message: "No table items found".to_string(),
         table_items: Vec::new(),
     }
 }
@@ -50,45 +141,4 @@ fn generate_success_response(table_items: Vec<TableItem>) -> ListTableItemsRespo
         message: format!("Found {} table item(s)", table_items.len()),
         table_items,
     }
-}
-
-fn generate_query(table_number: u32, items_ids: Option<Vec<u32>>, items_names: Option<Vec<String>>) -> String {
-    let mut query = format!(
-        "SELECT * FROM table_items WHERE table_number = '{}'",
-        table_number
-    );
-    let conditions = compute_conditions(items_ids, items_names);
-    if !conditions.is_empty() {
-        query.push_str(" AND ");
-        if conditions.len() == 2 {
-            query.push_str(&format!("( {} )", conditions.join(" OR ")));
-        } else {
-            query.push_str(&conditions.join(" OR "));
-        }
-    }
-    query
-}
-
-fn compute_conditions(items_ids: Option<Vec<u32>>,
-                      items_names: Option<Vec<String>>,
-) -> Vec<String> {
-    let mut conditions = Vec::new();
-
-    if let Some(ref items_ids) = items_ids {
-        if !items_ids.is_empty() {
-            let ids: Vec<String> = items_ids.iter().map(|id| id.to_string()).collect();
-            let ids_str = ids.join(", ");
-            conditions.push(format!("item_id IN ({})", ids_str));
-        }
-    }
-
-    if let Some(ref items_names) = items_names {
-        if !items_names.is_empty() {
-            let names: Vec<String> = items_names.iter().map(|name| format!("'{}'", name)).collect();
-            let names_str = names.join(", ");
-            conditions.push(format!("item_name IN ({})", names_str));
-        }
-    }
-
-    conditions
 }

--- a/src/repository/remove_table_items.rs
+++ b/src/repository/remove_table_items.rs
@@ -27,10 +27,7 @@ pub fn remove_table_item(
             if affected_rows > 0 {
                 Ok(generate_success_response(item_id))
             } else {
-                Ok(RemoveTableItemResponse {
-                    status: "success".to_string(),
-                    message: format!("No table item exists with item_id {}", item_id),
-                })
+                Ok(generate_absent_response(item_id))
             }
         }
         Err(e) => {
@@ -42,8 +39,12 @@ pub fn remove_table_item(
     }
 }
 
-
-
+fn generate_absent_response(item_id: u32) -> RemoveTableItemResponse {
+    RemoveTableItemResponse {
+        status: "success".to_string(),
+        message: format!("No table item exists with item_id {}", item_id),
+    }
+}
 
 fn generate_failed_response() -> RemoveTableItemResponse {
     RemoveTableItemResponse {


### PR DESCRIPTION
- This implements parameterised queries for fetching table items. However, it's not being merged into master to maintain clarity and simplicity in the main codebase.

- The implementation is somewhat complex due to the need for custom solutions, such as MySQL datetime to Rust datetime conversion, which aren't available out-of-the-box.

- We're keeping this separate for now, but it may be useful for future optimisations or when we're ready to handle the additional complexity.